### PR TITLE
Update package to 5.1.0 and add unique index methods

### DIFF
--- a/src/EFCore.PostgresExtensions/EFCore.PostgresExtensions.csproj
+++ b/src/EFCore.PostgresExtensions/EFCore.PostgresExtensions.csproj
@@ -8,13 +8,13 @@
         <PackageReadmeFile>Readme.md</PackageReadmeFile>
         <Authors>Pandatech</Authors>
         <Copyright>MIT</Copyright>
-        <Version>5.0.0</Version>
+        <Version>5.1.0</Version>
         <PackageId>Pandatech.EFCore.PostgresExtensions</PackageId>
         <Title>Pandatech.EFCore.PostgresExtensions</Title>
         <PackageTags>Pandatech, library, EntityFrameworkCore, PostgreSQL, For Update, Lock, LockingSyntax, Bulk insert, BinaryCopy</PackageTags>
         <Description>The Pandatech.EFCore.PostgresExtensions library enriches Entity Framework Core applications with advanced PostgreSQL functionalities, starting with the ForUpdate locking syntax and BulkInsert function. Designed for seamless integration, this NuGet package aims to enhance the efficiency and capabilities of EF Core models when working with PostgreSQL, with the potential for further PostgreSQL-specific extensions.</Description>
         <RepositoryUrl>https://github.com/PandaTechAM/be-lib-efcore-postgres-extensions</RepositoryUrl>
-        <PackageReleaseNotes>Removed bulk copy totally. Added Natural Sort functionality</PackageReleaseNotes>
+        <PackageReleaseNotes>Added support to generate unique index on encrypted columns</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EFCore.PostgresExtensions/Extensions/MigrationBuilderExtensions.cs
+++ b/src/EFCore.PostgresExtensions/Extensions/MigrationBuilderExtensions.cs
@@ -23,4 +23,40 @@ public static class MigrationBuilderExtensions
    {
       migrationBuilder.Sql(PgFunctionHelpers.GetNaturalSortKeyFunction());
    }
+
+   public static MigrationBuilder CreateUniqueIndexOnEncryptedColumn(this MigrationBuilder migrationBuilder,
+      string tableName,
+      string columnName,
+      string? condition)
+   {
+      var indexName = $"ix_{tableName}_{columnName}";
+      var whereClause = !string.IsNullOrWhiteSpace(condition) ? $" WHERE {condition}" : string.Empty;
+
+      var sql = $@"
+            CREATE UNIQUE INDEX {indexName}
+            ON {tableName} (substr({columnName}, 1, 64)){whereClause};";
+
+      migrationBuilder.Sql(sql);
+
+      return migrationBuilder;
+   }
+
+   public static MigrationBuilder CreateUniqueIndexOnEncryptedColumn(this MigrationBuilder migrationBuilder,
+      string tableName,
+      string columnName)
+   {
+      return migrationBuilder.CreateUniqueIndexOnEncryptedColumn(tableName, columnName, null);
+   }
+
+   public static MigrationBuilder DropUniqueIndexOnEncryptedColumn(this MigrationBuilder migrationBuilder,
+      string tableName,
+      string columnName)
+   {
+      var indexName = $"ix_{tableName}_{columnName}";
+
+      migrationBuilder.Sql($@"
+            DROP INDEX {indexName};");
+
+      return migrationBuilder;
+   }
 }


### PR DESCRIPTION
- Bump version from 5.0.0 to 5.1.0 in `EFCore.PostgresExtensions.csproj`.
- Update release notes to highlight support for unique indexes on encrypted columns.
- Add `CreateUniqueIndexOnEncryptedColumn` method for creating unique indexes with an optional condition.
- Introduce an overload of `CreateUniqueIndexOnEncryptedColumn` to simplify usage.
- Implement `DropUniqueIndexOnEncryptedColumn` method for removing unique indexes.
- `CreateNaturalSortKeyFunction` remains unchanged.